### PR TITLE
Disable certificate verification for domain list.

### DIFF
--- a/download_list.js
+++ b/download_list.js
@@ -20,6 +20,7 @@ function downloadFile (options, callback) {
   var request = https.request({
     host : options.host,
     path : options.path,
+    rejectUnauthorized : false,
     method : 'GET'
   });
 


### PR DESCRIPTION
For some reason, Debian and Ubuntu systems consider
the SSL certificate of publicsuffix.org invalid,
hence the downloading of the data (during the installation
of this package) fails.

This workaround disabled certificate validation for
the download.

Fixes #5.